### PR TITLE
Fixes typo in ratable model class_name

### DIFF
--- a/lib/ratable/models/ratable.rb
+++ b/lib/ratable/models/ratable.rb
@@ -8,7 +8,7 @@ module Ratable
       end
 
       included do
-        has_many :ratings, class_name: 'Ratable::Raiting', as: :ratings
+        has_many :ratings, class_name: 'Ratable::Rating', as: :ratings
       end
 
       def rating_average


### PR DESCRIPTION
Fixes small typo error in the Ratable model class_name namespacing
